### PR TITLE
FEATURE: prevent search engines from indexing the partly rendered document content

### DIFF
--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -35,10 +35,18 @@ prototype(Psmb.Ajaxify:Renderer) {
 	}
 }
 
+# Prevents search engines from indexing the partly rendered document content
+prototype(Psmb.Ajaxify:UnindexedResponse) < prototype(Neos.Fusion:Http.Message) {
+	httpResponseHead.headers {
+		X-Robots-Tag = 'noindex, follow'
+	}
+	content = Psmb.Ajaxify:Renderer
+}
+
 root.ajaxify {
 	@position = 'start'
 	condition = ${request.arguments.ajaxPathKey}
-	renderer = Psmb.Ajaxify:Renderer
+	renderer = Psmb.Ajaxify:UnindexedResponse
 }
 
 prototype(Psmb.Ajaxify:JsTag) < prototype(Neos.Fusion:Tag) {

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -15,7 +15,7 @@ prototype(Psmb.Ajaxify:Ajaxify) < prototype(Neos.Fusion:Tag) {
 	@if.disableProcessor = ${!request.arguments.ajaxPathKey && !documentNode.context.inBackend}
 	tagName = 'a'
 	attributes.data-ajaxify = ${true}
-	attributes.href = NodeUri {
+	attributes.href = Neos.Neos:NodeUri {
 		node = ${documentNode}
 		additionalParams.ajaxPathKey = Psmb.Ajaxify:RenderPath
 	}


### PR DESCRIPTION
This fixes #2 
Also includes an important bugfix commit to add support for Neos 4.x